### PR TITLE
Added check for OpenSSL v1.1.x.

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -1,5 +1,12 @@
 require 'openssl'
 
+# OpenSSL v1.1.x is required.
+openssl_version = OpenSSL::OPENSSL_LIBRARY_VERSION.split(' ')[1]
+if openssl_version.start_with? '1.0.' then
+  puts "Error: OpenSSL v1.1.x must be installed (you have #{openssl_version})."
+  exit -1
+end
+
 raw = File.read ARGV[0]
 ca = OpenSSL::X509::Certificate.new(raw) # Read certificate
 ca_key = ca.public_key # Parse public key from CA


### PR DESCRIPTION
Hopefully this prevents someone from wasting time like I did.  I was getting errors that I first thought had to do with an out-dated version of Ruby.  After installing lots of Ruby versions with `rvm`, I figured out that the problem was that my system only has OpenSSL v1.0.2g.